### PR TITLE
Add attune-ai to Code Quality Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Last updated: 2026-01-22 08:40 UTC
 | Plugin | Marketplace | Description | Author | Version |
 |--------|-------------|-------------|--------|---------|
 | [api-tester](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/api-tester) | awesome-claude-code-plugins | Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring ... | Michael Galpert | 1.0.0 |
+| [attune-ai](https://github.com/Smart-AI-Memory/attune-ai) | [PyPI](https://pypi.org/project/attune-ai/) | Security audits, code reviews, test generation, and release preparation for Claude Code with cost-optimized model routing | Smart AI Memory | 3.0.0 |
 | [bug-detective](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/bug-detective) | awesome-claude-code-plugins | Systematically debug issues with step-by-step troubleshooting approaches. | Anonymous | 1.0.0 |
 | [code-review](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/code-review) | awesome-claude-code-plugins | Perform a comprehensive code review of recent changes |  Anand Tyagi | 1.0.0 |
 | [code-review-assistant](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/code-review-assistant) | awesome-claude-code-plugins | Get comprehensive code reviews with suggestions for improvements, best practices, and potential issues. | Anonymous | 1.0.0 |


### PR DESCRIPTION
Adds [attune-ai](https://github.com/Smart-AI-Memory/attune-ai) to the Code Quality Testing category.

**What it does:** Security audits, code reviews, test generation, and release preparation for Claude Code with cost-optimized model routing across Claude Haiku, Sonnet, and Opus.

- [PyPI package](https://pypi.org/project/attune-ai/) (v3.0.0)
- Apache 2.0 licensed
- 18 MCP tools, 7 skills, 4 slash commands