### PR TITLE
Add encode-toolkit to bioinformatics category

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Last updated: 2026-01-22 08:40 UTC
 - [api-development](#api-development)
 - [assets](#assets)
 - [automation](#automation)
+- [bioinformatics](#bioinformatics)
 - [blockchain](#blockchain)
 - [btp](#btp)
 - [business](#business)
@@ -566,6 +567,12 @@ Last updated: 2026-01-22 08:40 UTC
 | [mattyp-changelog](https://github.com/jeremylongshore/claude-code-plugins-plus/tree/main/plugins/automation/mattyp-changelog) | claude-code-plugins-plus | Automates changelog generation from git history with config validation and quality scoring. Use when publishing weekly updates, release notes, or P... | Mattyp | 0.1.0 |
 | [n8n-mcp-skills](https://github.com/czlonkowski/n8n-skills/tree/main/) | czlonkowski/n8n-skills | Complete bundle: 7 expert skills for building flawless n8n workflows using n8n-mcp MCP server. Includes skills for expression syntax, MCP tools usa... | Romuald Członkowski | 1.0.0 |
 | [workflow-orchestrator](https://github.com/jeremylongshore/claude-code-plugins-plus/tree/main/plugins/mcp/workflow-orchestrator) | claude-code-plugins-plus | DAG-based workflow automation with parallel task execution and dependency management | Jeremy Longshore | 1.0.0 |
+
+## bioinformatics
+
+| Plugin | Marketplace | Description | Author | Version |
+|--------|-------------|-------------|--------|---------|
+| [encode-toolkit](https://github.com/ammawla/encode-toolkit) | ammawla/encode-toolkit | MCP server + Claude Code plugin for ENCODE Project genomics data. 20 tools, 47 skills, 14 database integrations, 7 analysis pipelines. Search expe... | Dr. Alex M. Mawla | 0.3.0-beta.3 |
 
 ## blockchain
 


### PR DESCRIPTION
## Summary

Adds [encode-toolkit](https://github.com/ammawla/encode-toolkit) — the first bioinformatics/genomics plugin for Claude Code.

- **20 MCP tools** for searching, downloading, and tracking ENCODE Project data
- **47 expert skills** covering analysis workflows, pipeline execution, and external database integration
- **14 database integrations**: ENCODE, PubMed, bioRxiv, ClinicalTrials.gov, Open Targets, GTEx, ClinVar, GWAS Catalog, JASPAR, gnomAD, Ensembl, UCSC, GEO, CELLxGENE
- **7 Nextflow pipelines**: ChIP-seq, ATAC-seq, RNA-seq, WGBS, Hi-C, DNase-seq, CUT&RUN

Creates a new `bioinformatics` category (alphabetically between `blockchain` and `btp`) and adds it to the Table of Contents.

**Install**: `claude mcp add encode -- uvx encode-toolkit`

**Registries**: [PyPI](https://pypi.org/project/encode-toolkit/) | [npm](https://www.npmjs.com/package/encode-toolkit) | [Glama](https://glama.ai/mcp/servers/ammawla/encode-toolkit)

**DOI**: [10.5281/zenodo.18917511](https://doi.org/10.5281/zenodo.18917511)

**License**: CC-BY-NC-ND-4.0