### PR TITLE
Add eight-eyes: hook-enforced multi-agent code review

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Last updated: 2026-01-22 08:40 UTC
 
 | Plugin | Marketplace | Description | Author | Version |
 |--------|-------------|-------------|--------|---------|
+| [8eyes](https://github.com/AgentBuildersApp/eight-eyes) | 8eyes-marketplace | Hook-enforced multi-agent code review with 8 constrained roles — blind skeptic, security auditor, verifier, and 5 more. Each scoped to a different failure surface. 142 tests, zero dependencies. Claude Code, Copilot CLI, Codex CLI. | AgentBuildersApp | 4.1.0 |
 | [api-tester](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/api-tester) | awesome-claude-code-plugins | Use this agent for comprehensive API testing including performance testing, load testing, and contract testing. This agent specializes in ensuring ... | Michael Galpert | 1.0.0 |
 | [bug-detective](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/bug-detective) | awesome-claude-code-plugins | Systematically debug issues with step-by-step troubleshooting approaches. | Anonymous | 1.0.0 |
 | [code-review](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/code-review) | awesome-claude-code-plugins | Perform a comprehensive code review of recent changes |  Anand Tyagi | 1.0.0 |


### PR DESCRIPTION
## eight-eyes

Hook-enforced multi-agent code review for Claude Code, Copilot CLI, and Codex CLI.

Splits a code change into 8 constrained roles — each aimed at a different failure surface. The skeptic reviews blind without the implementer's narrative. The security auditor cannot edit files. The verifier must prove acceptance criteria with evidence.

Prompts define behavior. Hooks enforce it.

- 142 tests, stdlib-only Python, zero dependencies
- Claude Code (full GA), Copilot CLI (full GA), Codex CLI (experimental)
- MIT licensed

https://github.com/AgentBuildersApp/eight-eyes