### PR TITLE
add authsome under Security, Compliance, &amp; Legal

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ Last updated: 2026-06-01 04:49 UTC
 | [enterprise-security-reviewer](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/enterprise-security-reviewer) | awesome-claude-code-plugins | Use this agent for comprehensive B2B security assessments, enterprise compliance validation, multi-tenant security reviews, and security audit prep... | Alysson Franklin | 1.0.0 |
 | [legal-advisor](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/legal-advisor) | awesome-claude-code-plugins | Use this agent when you need legal advisory, compliance documentation, RFP response creation, and enterprise contract support for B2B applications.... | Alysson Franklin | 1.0.0 |
 | [legal-compliance-checker](https://github.com/ccplugins/awesome-claude-code-plugins/tree/main/plugins/legal-compliance-checker) | awesome-claude-code-plugins | Use this agent when reviewing terms of service, privacy policies, ensuring regulatory compliance, or handling legal requirements. This agent excels... | Michael Galpert | 1.0.0 |
+| [authsome](https://github.com/agentrhq/authsome) | agentrhq/authsome | Local credential broker for AI agents. Log in once via OAuth2 or API key, encrypted local vault and a loopback HTTPS proxy inject credentials into outbound provider requests so the agent's process env never holds raw secrets. 45 providers bundled. Install via `/plugin marketplace add agentrhq/authsome` then `/plugin install authsome@authsome`. | Agentr | 0.3.2 |
 
 ## Uncategorized
 


### PR DESCRIPTION
hey, opening this to add authsome under Security, Compliance, & Legal.

authsome is a local credential broker for AI agents (Claude Code included). log in once via OAuth2 or API key, encrypted vault stores credentials, a local HTTPS proxy on loopback injects credentials into outbound provider requests so the agent's process env never holds raw secrets. 45 providers bundled (14 OAuth2, 31 API key) including github, google, openai, linear, slack, notion, resend, stripe.

ships a `.claude-plugin/marketplace.json` at the repo root, so claude code users install with `/plugin marketplace add agentrhq/authsome` then `/plugin install authsome@authsome`. SKILL.md lives at `skills/authsome/`.

the existing security entries are audit / compliance / governance agents. authsome is runtime infrastructure that complements those — keeps raw credentials out of the agent's process env and out of conversation context. happy to move it under a different section if you'd prefer.

repo: https://github.com/agentrhq/authsome
website: https://authsome.ai
license: MIT